### PR TITLE
Refactor SQL schema relative to scenario ID in session

### DIFF
--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -28,6 +28,7 @@ CREATE TABLE scenarios_power_plants
 CREATE TABLE sessions 
 (
   id UUID PRIMARY KEY,
+  scenario_id UUID REFERENCES scenarios_options (id) ON DELETE CASCADE,
   name TEXT UNIQUE,
   status TEXT CHECK (status IN ('open','running', 'closed'))
 );

--- a/server/src/routes/sessions.ts
+++ b/server/src/routes/sessions.ts
@@ -82,7 +82,7 @@ export async function openNewSession(
       id: uuidv4(),
       status: "open",
     };
-    await createNewSession(session, scenario_id);
+    await createNewSession(session);
     res.status(201).json(session);
   } catch (error) {
     res.status(error.code).end(error.msg);

--- a/server/src/routes/types.ts
+++ b/server/src/routes/types.ts
@@ -3,8 +3,9 @@
  */
 
 export interface Session {
-  name: string;
   id: string;
+  scenario_id?: string;
+  name: string;
   status: "open" | "running" | "closed";
 }
 


### PR DESCRIPTION
Until now, the session table did not have a scenario ID column,
while the options table had a scenario ID column, meaning a
delete of a scenario would cascade into a delete of the session options
while keeping the session record. This record would be oprhant as all
other relevant records (users, bids, etc.) would also be deleted on cascade.

This PR add a scenario_id column to the sessions table to have a more
coherent behavior regarding scenario deletion events.