### PR TITLE
Refactor tests

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -70,7 +70,7 @@ The following describes the various routes composing the parcelec API.
     - Body : 
     ``` js
       {
-        session_id: UUID string,
+        id: UUID string,
         name: string,
         status: 'open' | 'running' | 'closed'
       }

--- a/server/README.md
+++ b/server/README.md
@@ -69,11 +69,13 @@ The following describes the various routes composing the parcelec API.
     - Type : `application/json`,
     - Body : 
     ``` js
-      {
-        id: UUID string,
-        name: string,
-        status: 'open' | 'running' | 'closed'
-      }
+      [
+        {
+          id: UUID string,
+          name: string,
+          status: 'open' | 'running' | 'closed'
+        }
+      ]
     ```
     - `400` if a session already exists with this name
 

--- a/server/src/routes/bids.ts
+++ b/server/src/routes/bids.ts
@@ -41,11 +41,11 @@ export async function postUserBid(
     const session = await getSession(session_id);
     if (session === null)
       throw new CustomError("Error, no session found with this ID", 404);
-    if (session.status !== "running")
-      throw new CustomError("Error, the session is not running");
     const user = await getUser(session_id, user_id);
     if (user === null)
       throw new CustomError("Error, no user found with this ID", 404);
+    if (session.status !== "running")
+      throw new CustomError("Error, the session is not running");
 
     // Payload checks
     if (req.body.bid === undefined)

--- a/server/src/routes/portfolio.ts
+++ b/server/src/routes/portfolio.ts
@@ -47,7 +47,7 @@ export async function getUserPortfolio(
 
     const portfolio = await getPortfolio(user_id);
     const portfolio_with_planning = await addPlanningToPortfolio(portfolio);
-    await res.json(portfolio_with_planning);
+    res.json(portfolio_with_planning);
   } catch (error) {
     if (error instanceof CustomError) {
       res.status(error.code).end(error.msg);

--- a/server/src/routes/users.ts
+++ b/server/src/routes/users.ts
@@ -50,10 +50,10 @@ export async function registerNewUser(
 
     // Insertion
     const user_id = await insertNewUser(session_id, username);
-    res.status(201).json({ user_id: user_id });
-
     // Generate and attribute default portfolio
     await setDefaultPortfolio(session_id, user_id);
+
+    res.status(201).json({ user_id: user_id });
 
     // Notify all users that a new user has joined
     notifyUsersListUpdate(session_id);

--- a/server/src/routes/utils.ts
+++ b/server/src/routes/utils.ts
@@ -1011,3 +1011,37 @@ export async function getScenarioOptions(
   if (res.length === 1) scenario_options = res[0];
   return scenario_options;
 }
+
+/**
+ * Check if a session name already exists, and return `true` if not.
+ * @param session_name Session name
+ */
+export async function checkSessionName(session_name: string): Promise<boolean> {
+  return (
+    (
+      await db.query(
+        `SELECT id 
+        FROM sessions 
+        WHERE name=$1`,
+        [session_name]
+      )
+    ).rows.length === 0
+  );
+}
+
+/**
+ * Check if a scenario with a given ID exists, return true if yes.
+ * @param scenario_id Scenario ID
+ */
+export async function checkScenarioID(scenario_id: string): Promise<boolean> {
+  return (
+    (
+      await db.query(
+        `SELECT id 
+        FROM scenarios_options 
+        WHERE id=$1`,
+        [scenario_id]
+      )
+    ).rows.length === 1
+  );
+}

--- a/server/tests/integration/db_utils_new.ts
+++ b/server/tests/integration/db_utils_new.ts
@@ -9,6 +9,7 @@ import superagent from "superagent";
 import {
   PowerPlant,
   PowerPlantTemplate,
+  PowerPlantWithPlanning,
   ScenarioOptions,
   Session,
   User,
@@ -71,4 +72,35 @@ export async function setUserReady(
   user_id: string
 ): Promise<void> {
   await superagent.put(`${url}/session/${session_id}/user/${user_id}/ready`);
+}
+
+/**
+ * Return the portfolio of a user.
+ * @param session_id Session ID
+ * @param user_id User ID
+ */
+export async function getUserPortfolio(
+  session_id: string,
+  user_id: string
+): Promise<PowerPlantWithPlanning[]> {
+  const res = await superagent.get(
+    `${url}/session/${session_id}/user/${user_id}/portfolio`
+  );
+  return res.body;
+}
+
+/**
+ * Create a running session by inserting 2 users and marking them
+ * as ready.
+ * @param session_name Name of the session to create
+ */
+export async function insertRunningSession(
+  session_name: string
+): Promise<{ session_id: string; user_id_1: string; user_id_2: string }> {
+  const session_id = await insertNewSession(session_name);
+  const user_id_1 = await insertNewUser(session_id, "User 1");
+  const user_id_2 = await insertNewUser(session_id, "User 2");
+  await setUserReady(session_id, user_id_1);
+  await setUserReady(session_id, user_id_2);
+  return { session_id, user_id_1, user_id_2 };
 }

--- a/server/tests/integration/db_utils_new.ts
+++ b/server/tests/integration/db_utils_new.ts
@@ -121,3 +121,31 @@ export async function insertRunningSession(
   });
   return { session_id, user_id_1, user_id_2 };
 }
+
+/**
+ * Insert a bid on behalf of a user.
+ * @param session_id Session ID
+ * @param user_id User ID
+ * @param type Type of the bid (`sell` | `buy`). Default `sell`.
+ * @param volume_mwh Volume of the bid in MWh. Default 10 MWh.
+ * @param price_eur_per_mwh Price of the bid in €/MWh. Default 10 €/MWh.
+ */
+export async function insertBid(
+  session_id: string,
+  user_id: string,
+  type = "sell",
+  volume_mwh = 10,
+  price_eur_per_mwh = 10
+): Promise<string> {
+  return (
+    await superagent
+      .post(`${url}/session/${session_id}/user/${user_id}/bid`)
+      .send({
+        bid: {
+          type: type,
+          volume_mwh: volume_mwh,
+          price_eur_per_mwh: price_eur_per_mwh,
+        },
+      })
+  ).body.bid_id as string;
+}

--- a/server/tests/integration/db_utils_new.ts
+++ b/server/tests/integration/db_utils_new.ts
@@ -102,5 +102,22 @@ export async function insertRunningSession(
   const user_id_2 = await insertNewUser(session_id, "User 2");
   await setUserReady(session_id, user_id_1);
   await setUserReady(session_id, user_id_2);
+
+  // Wait for session to be in the 'running' state.
+  await new Promise((resolve, reject) => {
+    let i = 0;
+    const interval = setInterval(async () => {
+      const res = await superagent.get(`${url}/session/${session_id}`);
+      if (res.body.status === "running") {
+        resolve();
+        clearInterval(interval);
+      }
+      if (i > 5) {
+        reject();
+        clearInterval(interval);
+      }
+      i++;
+    }, 15);
+  });
   return { session_id, user_id_1, user_id_2 };
 }

--- a/server/tests/integration/db_utils_new.ts
+++ b/server/tests/integration/db_utils_new.ts
@@ -1,0 +1,47 @@
+/**
+ * Utility functions and data structures to make integration tests
+ * with the DB.
+ */
+
+import db from "../../src/db/index";
+import { v4 as uuid } from "uuid";
+import superagent from "superagent";
+import {
+  PowerPlant,
+  PowerPlantTemplate,
+  ScenarioOptions,
+  Session,
+  User,
+} from "../../src/routes/types";
+
+const url = process.env.API_URL;
+
+/**
+ * Remove all records from the DB using the property that `scenarios_options`
+ * table is referenced with ON DELETE CASCADE clauses by all other tables.
+ */
+export async function clearDB(): Promise<void> {
+  await db.query("DELETE FROM scenarios_options;", []);
+}
+
+/**
+ * Initialize the default scenario by calling the GET /scenarios route,
+ * and return the default scenario ID.
+ */
+export async function getDefaultScenarioID(): Promise<string> {
+  const res = await superagent.get(`${url}/scenarios`);
+  return res.body.id;
+}
+
+/**
+ * Insert a new session and return its ID.
+ */
+export async function insertNewSession(
+  session_name: string,
+  scenario_id?: string
+): Promise<string> {
+  const res = await superagent
+    .put(`${url}/session`)
+    .send({ session_name: session_name, scenario_id: scenario_id });
+  return res.body.id;
+}

--- a/server/tests/integration/db_utils_new.ts
+++ b/server/tests/integration/db_utils_new.ts
@@ -45,3 +45,30 @@ export async function insertNewSession(
     .send({ session_name: session_name, scenario_id: scenario_id });
   return res.body.id;
 }
+
+/**
+ * Register a new user to a game session and return its ID.
+ * @param session_id Session ID
+ * @param username Username
+ */
+export async function insertNewUser(
+  session_id: string,
+  username: string
+): Promise<string> {
+  const res = await superagent
+    .put(`${url}/session/${session_id}/register_user`)
+    .send({ username: username });
+  return res.body.user_id;
+}
+
+/**
+ * Register a new user to a game session and return its ID.
+ * @param session_id Session ID
+ * @param user_id User ID
+ */
+export async function setUserReady(
+  session_id: string,
+  user_id: string
+): Promise<void> {
+  await superagent.put(`${url}/session/${session_id}/user/${user_id}/ready`);
+}

--- a/server/tests/integration/routes_bids.spec.ts
+++ b/server/tests/integration/routes_bids.spec.ts
@@ -9,7 +9,14 @@
  */
 import { v4 as uuid, validate as uuidValidate } from "uuid";
 import superagent from "superagent";
-import { prepareDB, sessions, startSession, users } from "./db_utils";
+import {
+  clearDB,
+  getDefaultScenarioID,
+  getUserPortfolio,
+  insertNewSession,
+  insertNewUser,
+  insertRunningSession,
+} from "./db_utils_new";
 
 const url = process.env.API_URL;
 
@@ -17,8 +24,13 @@ const url = process.env.API_URL;
  * POST /session/:session_id/user/:user_id/bid
  */
 describe("Posting a bid to a running session", () => {
+  let session_id: string;
+  let user_id: string;
   beforeEach(async () => {
-    await prepareDB();
+    await clearDB();
+    await getDefaultScenarioID();
+    session_id = await insertNewSession("Session");
+    user_id = await insertNewUser(session_id, "User");
   });
 
   test("Should error when the session does not exist", async () => {
@@ -27,45 +39,42 @@ describe("Posting a bid to a running session", () => {
         .post(`${url}/session/${uuid()}/user/${uuid()}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
     } catch (error) {
-      expect(error.status).toEqual(404);
       expect(error.response.text).toEqual(
         "Error, no session found with this ID"
       );
+      expect(error.status).toEqual(404);
     }
   });
 
   test("Should error when the user does not exist", async () => {
     try {
       await superagent
-        .post(`${url}/session/${sessions[1].id}/user/${uuid()}/bid`)
+        .post(`${url}/session/${session_id}/user/${uuid()}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
     } catch (error) {
-      expect(error.status).toEqual(404);
       expect(error.response.text).toEqual("Error, no user found with this ID");
+      expect(error.status).toEqual(404);
     }
   });
 
   test("Should error when the session is not running", async () => {
     try {
-      const user_id = (
-        await superagent
-          .put(`${url}/session/${sessions[0].id}/register_user`)
-          .send({ username: "User" })
-      ).body.user_id;
       await superagent
-        .post(`${url}/session/${sessions[0].id}/user/${user_id}/bid`)
+        .post(`${url}/session/${session_id}/user/${user_id}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
     } catch (error) {
-      expect(error.status).toEqual(400);
       expect(error.response.text).toEqual("Error, the session is not running");
+      expect(error.status).toEqual(400);
     }
   });
 
   test("should success when the session is running", async () => {
     try {
-      const users_id = await startSession(url, sessions[0].id);
+      const { session_id, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
       const res = await superagent
-        .post(`${url}/session/${sessions[0].id}/user/${users_id[0]}/bid`)
+        .post(`${url}/session/${session_id}/user/${user_id_1}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
       expect(res.status).toEqual(201);
       expect(res.body).toHaveProperty("bid_id");
@@ -80,53 +89,51 @@ describe("Posting a bid to a running session", () => {
  * GET /session/:session_id/user/:user_id/bids
  */
 describe("Getting a user's bids", () => {
+  let session_id: string;
+  let user_id: string;
   beforeEach(async () => {
-    await prepareDB();
+    await clearDB();
+    await getDefaultScenarioID();
+    session_id = await insertNewSession("Session");
+    user_id = await insertNewUser(session_id, "User");
   });
 
   test("Should error when the session does not exist", async () => {
     try {
       await superagent.get(`${url}/session/${uuid()}/user/${uuid()}/bids`);
     } catch (error) {
-      expect(error.status).toEqual(404);
       expect(error.response.text).toEqual(
         "Error, no session found with this ID"
       );
+      expect(error.status).toEqual(404);
     }
   });
 
   test("Should error when the user does not exist", async () => {
     try {
-      await superagent.get(
-        `${url}/session/${sessions[1].id}/user/${uuid()}/bids`
-      );
+      await superagent.get(`${url}/session/${session_id}/user/${uuid()}/bids`);
     } catch (error) {
-      expect(error.status).toEqual(404);
       expect(error.response.text).toEqual("Error, no user found with this ID");
+      expect(error.status).toEqual(404);
     }
   });
 
   test("Should error when the session is not running", async () => {
     try {
-      const user_id = (
-        await superagent
-          .put(`${url}/session/${sessions[0].id}/register_user`)
-          .send({ username: "User" })
-      ).body.user_id;
-      await superagent.get(
-        `${url}/session/${sessions[0].id}/user/${user_id}/bids`
-      );
+      await superagent.get(`${url}/session/${session_id}/user/${user_id}/bids`);
     } catch (error) {
-      expect(error.status).toEqual(400);
       expect(error.response.text).toEqual("Error, the session is not running");
+      expect(error.status).toEqual(400);
     }
   });
 
   test("should return empty list when no bids", async () => {
     try {
-      const users_id = await startSession(url, sessions[0].id);
+      const { session_id, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
       const res = await superagent.get(
-        `${url}/session/${sessions[0].id}/user/${users_id[0]}/bids`
+        `${url}/session/${session_id}/user/${user_id_1}/bids`
       );
       expect(res.status).toEqual(200);
       expect(Array.isArray(res.body)).toEqual(true);
@@ -138,12 +145,14 @@ describe("Getting a user's bids", () => {
 
   test("should return the correct bid content", async () => {
     try {
-      const users_id = await startSession(url, sessions[0].id);
+      const { session_id: sid, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
       await superagent
-        .post(`${url}/session/${sessions[0].id}/user/${users_id[0]}/bid`)
+        .post(`${url}/session/${sid}/user/${user_id_1}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
       const res = await superagent.get(
-        `${url}/session/${sessions[0].id}/user/${users_id[0]}/bids`
+        `${url}/session/${sid}/user/${user_id_1}/bids`
       );
       expect(res.status).toEqual(200);
       expect(Array.isArray(res.body)).toEqual(true);
@@ -153,24 +162,28 @@ describe("Getting a user's bids", () => {
       expect(res.body[0].price_eur_per_mwh).toEqual(50);
       expect(uuidValidate(res.body[0].id)).toEqual(true);
     } catch (err) {
+      console.log(err);
+
       fail(err);
     }
   });
 
   test("should return the correct number of bids", async () => {
     try {
-      const users_id = await startSession(url, sessions[0].id);
+      const { session_id, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
       await superagent
-        .post(`${url}/session/${sessions[0].id}/user/${users_id[0]}/bid`)
+        .post(`${url}/session/${session_id}/user/${user_id_1}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
       await superagent
-        .post(`${url}/session/${sessions[0].id}/user/${users_id[0]}/bid`)
+        .post(`${url}/session/${session_id}/user/${user_id_1}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
       await superagent
-        .post(`${url}/session/${sessions[0].id}/user/${users_id[0]}/bid`)
+        .post(`${url}/session/${session_id}/user/${user_id_1}/bid`)
         .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } });
       const res = await superagent.get(
-        `${url}/session/${sessions[0].id}/user/${users_id[0]}/bids`
+        `${url}/session/${session_id}/user/${user_id_1}/bids`
       );
       expect(res.status).toEqual(200);
       expect(Array.isArray(res.body)).toEqual(true);
@@ -185,8 +198,13 @@ describe("Getting a user's bids", () => {
  * DELETE /session/:session_id/user/:user_id/bid/:bid_id
  */
 describe("Deleting a user's bid", () => {
+  let session_id: string;
+  let user_id: string;
   beforeEach(async () => {
-    await prepareDB();
+    await clearDB();
+    await getDefaultScenarioID();
+    session_id = await insertNewSession("Session");
+    user_id = await insertNewUser(session_id, "User");
   });
 
   test("Should error when the session does not exist", async () => {
@@ -195,50 +213,53 @@ describe("Deleting a user's bid", () => {
         `${url}/session/${uuid()}/user/${uuid()}/bid/${uuid()}`
       );
     } catch (error) {
-      expect(error.status).toEqual(404);
       expect(error.response.text).toEqual(
         "Error, no session found with this ID"
       );
+      expect(error.status).toEqual(404);
     }
   });
 
   test("Should error when the user does not exist", async () => {
     try {
       await superagent.delete(
-        `${url}/session/${sessions[1].id}/user/${uuid()}/bid/${uuid()}`
+        `${url}/session/${session_id}/user/${uuid()}/bid/${uuid()}`
       );
     } catch (error) {
-      expect(error.status).toEqual(404);
       expect(error.response.text).toEqual("Error, no user found with this ID");
+      expect(error.status).toEqual(404);
     }
   });
 
   test("Should error when the bid does not exist", async () => {
     try {
+      const { session_id, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
       await superagent.delete(
-        `${url}/session/${users[0].session_id}/user/${
-          users[0].id
-        }/bid/${uuid()}`
+        `${url}/session/${session_id}/user/${user_id_1}/bid/${uuid()}`
       );
     } catch (error) {
-      expect(error.status).toEqual(404);
       expect(error.response.text).toEqual("Error, no bid found with this ID");
+      expect(error.status).toEqual(404);
     }
   });
 
   test("Should delete the bid", async () => {
     try {
-      const users_id = await startSession(url, sessions[0].id);
+      const { session_id, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
       // Add a bid
       const bid_id = (
         await superagent
-          .post(`${url}/session/${sessions[0].id}/user/${users_id[0]}/bid`)
+          .post(`${url}/session/${session_id}/user/${user_id_1}/bid`)
           .send({ bid: { type: "buy", volume_mwh: 10, price_eur_per_mwh: 50 } })
       ).body.bid_id;
 
       // Check the bid has been inserted
       const res_bids_1 = await superagent.get(
-        `${url}/session/${sessions[0].id}/user/${users_id[0]}/bids`
+        `${url}/session/${session_id}/user/${user_id_1}/bids`
       );
       expect(Array.isArray(res_bids_1.body)).toEqual(true);
       expect(res_bids_1.body.length).toEqual(1);
@@ -246,13 +267,13 @@ describe("Deleting a user's bid", () => {
 
       // Delete the bid
       const res_delete = await superagent.delete(
-        `${url}/session/${sessions[0].id}/user/${users_id[0]}/bid/${bid_id}`
+        `${url}/session/${session_id}/user/${user_id_1}/bid/${bid_id}`
       );
       expect(res_delete.status).toEqual(200);
 
       // Check there are no longer bids for that user
       const res_bids_2 = await superagent.get(
-        `${url}/session/${sessions[0].id}/user/${users_id[0]}/bids`
+        `${url}/session/${session_id}/user/${user_id_1}/bids`
       );
       expect(res_bids_2.body.length).toEqual(0);
     } catch (err) {

--- a/server/tests/integration/routes_sessions.spec.ts
+++ b/server/tests/integration/routes_sessions.spec.ts
@@ -14,6 +14,7 @@ import {
   clearDB,
   getDefaultScenarioID,
   insertNewSession,
+  insertRunningSession,
 } from "./db_utils_new";
 
 const url = process.env.API_URL;
@@ -189,7 +190,7 @@ describe("Listing open game sessions", () => {
  */
 describe("Retrieving session public infos", () => {
   let session_id: string;
-  beforeAll(async () => {
+  beforeEach(async () => {
     await clearDB();
     await getDefaultScenarioID();
     session_id = await insertNewSession("Session");
@@ -200,5 +201,13 @@ describe("Retrieving session public infos", () => {
     expect(res.body.id).toEqual(session_id);
     expect(res.body.name).toEqual("Session");
     expect(res.body.users.length).toEqual(0);
+  });
+
+  test("Should get basic infos for a session with users", async () => {
+    const { session_id } = await insertRunningSession("Running Session");
+    const res = await superagent.get(`${url}/session/${session_id}`);
+    expect(res.body.id).toEqual(session_id);
+    expect(res.body.name).toEqual("Running Session");
+    expect(res.body.users.length).toEqual(2);
   });
 });


### PR DESCRIPTION
Fix the tests following https://github.com/thomas-god/parcelec/pull/13#issuecomment-696693797.

For the tests to be more maintainable, instead of using direct db.query calls to populate the DB with tests data, we now use the API endpoints themselves, as it avoids mimicking side effects (e.g. creating a portfolio on user registration).