### PR TITLE
Add direct exchanges (OTC) feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ dist
 # DB dev data
 **/db/data
 /resources
+
+.env.development

--- a/client/src/components/AddNewOTC.vue
+++ b/client/src/components/AddNewOTC.vue
@@ -1,0 +1,294 @@
+<template>
+  <div>
+    <h3>Faire une offre directe</h3>
+    <div class="new_otc__inputs__container">
+      <div class="new_otc__input_item">
+        <label for="new__otc_user_to">Joueur</label>
+        <select id="new__otc_user_to" v-model="user_to">
+          <option
+            v-for="user in otherUsers"
+            :value="user.name"
+            :key="user.name"
+            >{{ user.name }}</option
+          >
+        </select>
+        <span class="err_msg">{{
+          show_err_msg ? inputs_err_msg_user_to : ""
+        }}</span>
+      </div>
+
+      <div class="new_otc__input_item">
+        <label for="new__otc_type">Type</label>
+        <select name="Achat ou vente" id="new__otc_user_to" v-model="type">
+          <option value="buy">Acheter</option>
+          <option value="sell">Vendre</option>
+        </select>
+        <span class="err_msg">{{
+          show_err_msg ? inputs_err_msg_type : ""
+        }}</span>
+      </div>
+
+      <div class="new_otc__input_item">
+        <label for="new__otc_volume_mwh">Volume (MWh)</label>
+        <input
+          type="number"
+          id="new__otc_volume_mwh"
+          min="0"
+          step="1"
+          v-model="volume_mwh"
+        />
+        <span class="err_msg">{{
+          show_err_msg ? inputs_err_msg_volume : ""
+        }}</span>
+      </div>
+
+      <div class="new_otc__input_item">
+        <label for="new__otc_price_eur_per_mwh">Prix (€/MWh) </label>
+        <input
+          type="number"
+          id="new__otc_price_eur_per_mwh"
+          step="0.01"
+          v-model="price_eur_per_mwh"
+        />
+        <span class="err_msg">{{
+          show_err_msg ? inputs_err_msg_price : ""
+        }}</span>
+      </div>
+    </div>
+    <Btn @click="postOTC"> Envoyer </Btn>
+  </div>
+</template>
+
+<script lang='ts'>
+import { Component, Vue, Watch, Prop } from "vue-property-decorator";
+import { State, namespace } from "vuex-class";
+import { v4 as uuid } from "uuid";
+import { OTC } from "../store/otc";
+import { User } from "../store/session";
+import Btn from "./base/Button.vue";
+
+const user_module = namespace("user");
+const otcs_module = namespace("otcs");
+const session_module = namespace("session");
+
+@Component({ components: { Btn } })
+export default class NewOTC extends Vue {
+  @Prop({ default: false }) dummy!: boolean;
+  @session_module.State users!: User[];
+  @user_module.Getter username!: string;
+  @otcs_module.State otcs!: OTC[];
+
+  get otherUsers(): User[] {
+    return this.users.filter(u => u.name !== this.username);
+  }
+
+  /**
+   * Inputs validation
+   */
+  user_to = "";
+  type = "";
+  volume_mwh = "";
+  price_eur_per_mwh = "";
+
+  inputs_err_msg_user_to = "";
+  inputs_err_msg_type = "";
+  inputs_err_msg_volume = "";
+  inputs_err_msg_price = "";
+  show_err_msg = true;
+
+  validateInputs(): boolean {
+    return [
+      this.validateVolume(),
+      this.validatePrice(),
+      this.validateUserTo(),
+      this.validateType()
+    ].every(val => val);
+  }
+
+  @Watch("user_to")
+  validateUserTo(): boolean {
+    const flag = this.otherUsers.map(u => u.name).includes(this.user_to);
+    this.inputs_err_msg_user_to = flag ? "" : "Choissez un joueur";
+    return flag;
+  }
+
+  @Watch("type")
+  validateType(): boolean {
+    const flag = ["sell", "buy"].includes(this.type);
+    this.inputs_err_msg_type = flag ? "" : "Choissez une action";
+    return flag;
+  }
+
+  @Watch("volume_mwh")
+  validateVolume(): boolean {
+    let flag = true;
+    if (this.show_err_msg) {
+      if (isNaN(Number(this.volume_mwh)) || this.volume_mwh === "") {
+        flag = false;
+        this.inputs_err_msg_volume = "Le volume doit être un nombre";
+      } else if (Number(this.volume_mwh) <= 0) {
+        flag = false;
+        this.inputs_err_msg_volume = "Le volume doit être positif";
+      } else {
+        this.inputs_err_msg_volume = "";
+      }
+    }
+    return flag;
+  }
+
+  @Watch("price_eur_per_mwh")
+  validatePrice(): boolean {
+    let flag = true;
+    if (this.show_err_msg) {
+      if (
+        isNaN(Number(this.price_eur_per_mwh)) ||
+        this.price_eur_per_mwh === ""
+      ) {
+        flag = false;
+        this.inputs_err_msg_price = "Le prix doit être un nombre";
+      } else {
+        this.inputs_err_msg_price = "";
+      }
+    }
+    return flag;
+  }
+
+  hideErrMsg(): void {
+    this.show_err_msg = false;
+    setTimeout(() => {
+      this.inputs_err_msg_user_to = "";
+      this.inputs_err_msg_type = "";
+      this.inputs_err_msg_price = "";
+      this.inputs_err_msg_volume = "";
+      this.show_err_msg = true;
+    }, 200);
+  }
+
+  /**
+   * POST OTC
+   */
+  @State api_url!: string;
+  @session_module.Getter session_id!: string;
+  @user_module.Getter user_id!: string;
+  @otcs_module.Mutation PUSH_OTC!: (otc: OTC) => void;
+  async postOTC() {
+    if (!this.dummy && this.validateInputs()) {
+      const res = await fetch(
+        `${this.api_url}/session/${this.session_id}/user/${this.user_id}/otc`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            user_from: this.username,
+            user_to: this.user_to,
+            type: this.type as "sell" | "buy",
+            volume_mwh: Number(this.volume_mwh),
+            price_eur_per_mwh: Number(this.price_eur_per_mwh),
+            status: "pending"
+          })
+        }
+      );
+      if (res.status === 201) {
+        const otc_id = (await res.json()).otc_id;
+        this.PUSH_OTC({
+          id: otc_id,
+          user_from: this.username,
+          user_to: this.user_to,
+          type: this.type as "sell" | "buy",
+          volume_mwh: Number(this.volume_mwh),
+          price_eur_per_mwh: Number(this.price_eur_per_mwh),
+          status: "pending"
+        });
+        this.hideErrMsg();
+        this.user_to = "";
+        this.type = "";
+        this.volume_mwh = "";
+        this.price_eur_per_mwh = "";
+      } else {
+        console.log(await res.text());
+      }
+    } else if (this.validateInputs()) {
+      this.PUSH_OTC({
+        id: uuid(),
+        user_from: this.username,
+        user_to: this.user_to,
+        type: this.type as "sell" | "buy",
+        volume_mwh: Number(this.volume_mwh),
+        price_eur_per_mwh: Number(this.price_eur_per_mwh),
+        status: "pending"
+      });
+      this.hideErrMsg();
+      this.user_to = "";
+      this.type = "";
+      this.volume_mwh = "";
+      this.price_eur_per_mwh = "";
+    }
+  }
+}
+</script>
+
+<style scoped>
+.new_otc__inputs__container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.new_otc__input_item {
+  display: grid;
+  grid-template-areas:
+    "label input"
+    "err err";
+  grid-template-columns: 130px 150px;
+  grid-template-rows: 1.7rem 1.4rem;
+  margin-bottom: 0rem;
+  column-gap: 1rem;
+  align-items: center;
+}
+.new_otc__input_item label {
+  grid-area: label;
+}
+.new_otc__input_item input {
+  grid-area: input;
+}
+.new_otc__input_item .err_msg {
+  grid-area: err;
+  text-align: end;
+  font-style: italic;
+  font-size: 0.9rem;
+  color: red;
+}
+
+input,
+select {
+  box-sizing: border-box;
+  width: 150px;
+  height: 1.7rem;
+}
+label {
+  display: inline-block;
+  margin-right: 1rem;
+  width: 130px;
+  text-align: end;
+}
+
+select,
+select > option,
+input[type="number"] {
+  font-family: Montserrat;
+  font-size: 1rem;
+  text-align: center;
+}
+
+/* Chrome, Safari, Edge, Opera */
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+/* Firefox */
+input[type="number"] {
+  -moz-appearance: textfield;
+}
+</style>

--- a/client/src/components/Chatroom.vue
+++ b/client/src/components/Chatroom.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="chatroom__container">
+    <h2>Messages</h2>
     <ChatroomMessages class="chatroom__box chatroom__messages" />
     <ChatroomUsersList
       class="chatroom__box chatroom__users_list"
@@ -20,6 +21,9 @@ export default class Chatroom extends Vue {
 </script>
 
 <style scoped>
+h2 {
+  margin-top: 0;
+}
 @media screen and (min-width: 750px) {
   .chatroom__container {
     display: flex;

--- a/client/src/components/ChatroomMessages.vue
+++ b/client/src/components/ChatroomMessages.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <h3>Messages</h3>
     <ul class="message__messages">
       <li v-for="msg in messages" :key="msg.date" class="message__msg">
         <span class="message__msg_user">{{ msg.username }} :</span>

--- a/client/src/components/Main.vue
+++ b/client/src/components/Main.vue
@@ -58,14 +58,14 @@
         Grid main
       -->
       <div class="app__grid_main">
-        <Bilans
-          class="app__main_item"
-          v-show="
-            results_available &&
-              (active_category === 'Home' || active_category === 'Résultats')
-          "
-        />
         <div class="app__main">
+          <Bilans
+            class="app__main_item"
+            v-show="
+              results_available &&
+                (active_category === 'Home' || active_category === 'Résultats')
+            "
+          />
           <PowerPlantsList
             class="app__main_item"
             :show_actions="!results_available"
@@ -84,9 +84,8 @@
           <Chatroom
             class="app__main_item"
             v-show="active_category === 'Chat'"
-            style="padding: 1rem; max-width: 500px;"
           />
-          <OTC v-show="active_category === 'Home'" class="app__main_item" />
+          <OTC v-show="active_category === 'Marché'" class="app__main_item" />
         </div>
       </div>
     </div>
@@ -129,7 +128,7 @@ const resultsModule = namespace("results");
     TimersText,
     Waitroom,
     MainTabs,
-    OTC,
+    OTC
   }
 })
 export default class Main extends Vue {
@@ -252,7 +251,7 @@ function toTimeString(dt: number): string {
     margin: 2rem;
     border-radius: 2px;
     border: 2px solid gray;
-    padding: 10px
+    padding: 10px;
   }
   .app__footer_bilans {
     font-size: 2rem;

--- a/client/src/components/Main.vue
+++ b/client/src/components/Main.vue
@@ -86,7 +86,7 @@
             v-show="active_category === 'Chat'"
             style="padding: 1rem; max-width: 500px;"
           />
-          <AddNewOTC v-show="active_category === 'Home'" class="app__main_item" />
+          <OTC v-show="active_category === 'Home'" class="app__main_item" />
         </div>
       </div>
     </div>
@@ -110,7 +110,7 @@ import Btn from "./base/Button.vue";
 import TimersText from "./TimersText.vue";
 import Waitroom from "./Waitroom.vue";
 import MainTabs from "./MainTabs.vue";
-import AddNewOTC from "./AddNewOTC.vue";
+import OTC from "./OTC.vue";
 
 const userModule = namespace("user");
 const sessionModule = namespace("session");
@@ -129,7 +129,7 @@ const resultsModule = namespace("results");
     TimersText,
     Waitroom,
     MainTabs,
-    AddNewOTC
+    OTC,
   }
 })
 export default class Main extends Vue {
@@ -252,6 +252,7 @@ function toTimeString(dt: number): string {
     margin: 2rem;
     border-radius: 2px;
     border: 2px solid gray;
+    padding: 10px
   }
   .app__footer_bilans {
     font-size: 2rem;

--- a/client/src/components/Main.vue
+++ b/client/src/components/Main.vue
@@ -86,6 +86,7 @@
             v-show="active_category === 'Chat'"
             style="padding: 1rem; max-width: 500px;"
           />
+          <AddNewOTC v-show="active_category === 'Home'" class="app__main_item" />
         </div>
       </div>
     </div>
@@ -109,6 +110,7 @@ import Btn from "./base/Button.vue";
 import TimersText from "./TimersText.vue";
 import Waitroom from "./Waitroom.vue";
 import MainTabs from "./MainTabs.vue";
+import AddNewOTC from "./AddNewOTC.vue";
 
 const userModule = namespace("user");
 const sessionModule = namespace("session");
@@ -126,7 +128,8 @@ const resultsModule = namespace("results");
     Btn,
     TimersText,
     Waitroom,
-    MainTabs
+    MainTabs,
+    AddNewOTC
   }
 })
 export default class Main extends Vue {

--- a/client/src/components/OTC.vue
+++ b/client/src/components/OTC.vue
@@ -1,28 +1,33 @@
-<template> 
-<div>
+<template>
+  <div>
     <h2>Contrats directs</h2>
-    <h3>Proposer un contrat</h3>
-    <OTCAddNew/>
-    <OTCList/>
-</div>
+    <h3 v-if="can_post_planning">Proposer un contrat</h3>
+    <OTCAddNew v-if="can_post_planning" />
+    <OTCList />
+  </div>
 </template>
 
 <script lang='ts'>
 import { Vue, Component } from "vue-property-decorator";
+import { namespace } from "vuex-class";
 import OTCAddNew from "./OTCAddNew.vue";
 import OTCList from "./OTCList.vue";
 
+const session_module = namespace("session");
+
 @Component({ components: { OTCAddNew, OTCList } })
-export default class OTC extends Vue {}
+export default class OTC extends Vue {
+  @session_module.Getter can_post_planning!: boolean;
+}
 </script>
 
 <style scoped>
 h2 {
-    margin-top: 0;
+  margin-top: 0;
 }
 h3 {
-    margin-left: 0;
-    padding-left: 2rem;
-    text-align: start;
+  margin-left: 0;
+  padding-left: 2rem;
+  text-align: start;
 }
 </style>

--- a/client/src/components/OTC.vue
+++ b/client/src/components/OTC.vue
@@ -1,0 +1,29 @@
+<template> 
+<div>
+    <h2>Contrats directs</h2>
+    <h3>Proposer un contrat</h3>
+    <OTCAddNew/>
+    <h3>Vos contrats</h3>
+    <OTCList/>
+</div>
+</template>
+
+<script lang='ts'>
+import { Vue, Component } from "vue-property-decorator";
+import OTCAddNew from "./OTCAddNew.vue";
+import OTCList from "./OTCList.vue";
+
+@Component({ components: { OTCAddNew, OTCList } })
+export default class OTC extends Vue {}
+</script>
+
+<style scoped>
+h2 {
+    margin-top: 0;
+}
+h3 {
+    margin-left: 0;
+    padding-left: 2rem;
+    text-align: start;
+}
+</style>

--- a/client/src/components/OTC.vue
+++ b/client/src/components/OTC.vue
@@ -3,7 +3,6 @@
     <h2>Contrats directs</h2>
     <h3>Proposer un contrat</h3>
     <OTCAddNew/>
-    <h3>Vos contrats</h3>
     <OTCList/>
 </div>
 </template>

--- a/client/src/components/OTCAddNew.vue
+++ b/client/src/components/OTCAddNew.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <h3>Faire une offre directe</h3>
     <div class="new_otc__inputs__container">
       <div class="new_otc__input_item">
         <label for="new__otc_user_to">Joueur</label>

--- a/client/src/components/OTCAddNew.vue
+++ b/client/src/components/OTCAddNew.vue
@@ -178,12 +178,10 @@ export default class NewOTC extends Vue {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
-            user_from: this.username,
             user_to: this.user_to,
             type: this.type as "sell" | "buy",
             volume_mwh: Number(this.volume_mwh),
             price_eur_per_mwh: Number(this.price_eur_per_mwh),
-            status: "pending"
           })
         }
       );

--- a/client/src/components/OTCItem.vue
+++ b/client/src/components/OTCItem.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="otc_item__container">
-    <div class="otc_item__users">
-      <strong>{{ item.user_to }}</strong> ->
-      <strong>{{ item.user_from }}</strong> ({{ item.status }})
+    <div class="otc_item__users" v-if="type === 'send'">
+      A <strong>{{ item.user_to }}</strong> ({{ otc_status }})
+    </div>
+    <div class="otc_item__users" v-if="type === 'received'">
+      De <strong>{{ item.user_from }}</strong> ({{ otc_status }})
     </div>
     <div class="otc_item__details">
-      {{ OTCAction }} <strong>{{ item.volume_mwh }}</strong> MWh à
-      <strong>{{ item.price_eur_per_mwh }}</strong> €/MWh
-    </div>
-    <div class="otc_item__details">
-      Total <strong>{{priceTotal}} €</strong>
+      {{ otc_action }} <strong>{{ item.volume_mwh }}</strong> MWh à
+      <strong>{{ item.price_eur_per_mwh }}</strong> €/MWh (total
+      <strong>{{ price_total.toFixed(2) }} €</strong>)
     </div>
   </div>
 </template>
@@ -21,20 +21,43 @@ import { OTC } from "../store/otc";
 @Component
 export default class OTCItem extends Vue {
   @Prop() item!: OTC;
+  @Prop() type!: "send" | "received";
 
-  get OTCAction(): string {
-    if (this.item.type === "buy") {
-      return "Acheter";
-    } else if (this.item.type === "sell") {
-      return "Vendre";
+  get otc_action(): string {
+    if (this.type === "send") {
+      if (this.item.type === "buy") {
+        return "Acheter";
+      } else if (this.item.type === "sell") {
+        return "Vendre";
+      } else return "";
+    } else if (this.type === "received") {
+      if (this.item.type === "buy") {
+        return "Vendre";
+      } else if (this.item.type === "sell") {
+        return "Acheter";
+      } else return "";
     } else {
       return "";
     }
   }
 
-  get priceTotal(): number {
+  get otc_status(): string {
+    switch (this.item.status) {
+      case "pending":
+        return "en cours";
+      case "accepted":
+        return "accepté";
+      case "rejected":
+        return "refusé";
+      default:
+        return "";
+    }
+  }
+
+  get price_total(): number {
     return (
       (this.item.type === "sell" ? 1 : -1) *
+      (this.type === "send" ? 1 : -1) *
       this.item.volume_mwh *
       this.item.price_eur_per_mwh
     );
@@ -43,7 +66,7 @@ export default class OTCItem extends Vue {
 </script>
 <style scoped>
 .otc_item__container {
-  padding: 0 10px
+  padding: 0 10px;
 }
 .otc_item__users {
   text-align: start;
@@ -52,5 +75,4 @@ export default class OTCItem extends Vue {
 .otc_item__details {
   text-align: start;
 }
-
 </style>

--- a/client/src/components/OTCItem.vue
+++ b/client/src/components/OTCItem.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="otc_item__container">
+    <div class="otc_item__users">
+      <strong>{{ item.user_to }}</strong> ->
+      <strong>{{ item.user_from }}</strong> ({{ item.status }})
+    </div>
+    <div class="otc_item__details">
+      {{ OTCAction }} <strong>{{ item.volume_mwh }}</strong> MWh à
+      <strong>{{ item.price_eur_per_mwh }}</strong> €/MWh
+    </div>
+    <div class="otc_item__details">
+      Total <strong>{{priceTotal}} €</strong>
+    </div>
+  </div>
+</template>
+
+<script lang='ts'>
+import { Vue, Component, Prop } from "vue-property-decorator";
+import { OTC } from "../store/otc";
+
+@Component
+export default class OTCItem extends Vue {
+  @Prop() item!: OTC;
+
+  get OTCAction(): string {
+    if (this.item.type === "buy") {
+      return "Acheter";
+    } else if (this.item.type === "sell") {
+      return "Vendre";
+    } else {
+      return "";
+    }
+  }
+
+  get priceTotal(): number {
+    return (
+      (this.item.type === "sell" ? 1 : -1) *
+      this.item.volume_mwh *
+      this.item.price_eur_per_mwh
+    );
+  }
+}
+</script>
+<style scoped>
+.otc_item__container {
+  padding: 0 10px
+}
+.otc_item__users {
+  text-align: start;
+  padding-left: 1rem;
+}
+.otc_item__details {
+  text-align: start;
+}
+
+</style>

--- a/client/src/components/OTCItem.vue
+++ b/client/src/components/OTCItem.vue
@@ -1,27 +1,48 @@
 <template>
-  <div class="otc_item__container">
-    <div class="otc_item__users" v-if="type === 'send'">
+  <div
+    class="otc_item__container"
+    :class="item.status === 'rejected' ? 'otc_item__container_refused' : ''"
+  >
+    <div class="otc_item__user" v-if="type === 'send'">
       A <strong>{{ item.user_to }}</strong> ({{ otc_status }})
     </div>
-    <div class="otc_item__users" v-if="type === 'received'">
+    <div class="otc_item__user" v-if="type === 'received'">
       De <strong>{{ item.user_from }}</strong> ({{ otc_status }})
     </div>
     <div class="otc_item__details">
       {{ otc_action }} <strong>{{ item.volume_mwh }}</strong> MWh à
-      <strong>{{ item.price_eur_per_mwh }}</strong> €/MWh (total
-      <strong>{{ price_total.toFixed(2) }} €</strong>)
+      <strong>{{ item.price_eur_per_mwh }}</strong> €/MWh
+      <div>Total {{ price_total.toFixed(2) }} €</div>
+    </div>
+    <div
+      class="otc_item__actions"
+      v-if="
+        item.status === 'pending' && type === 'received' && can_post_planning
+      "
+    >
+      <Btn :background_color="'green'" @click="acceptOTC">OK</Btn>
+      <Btn :background_color="'red'" @click="rejectOTC">X</Btn>
     </div>
   </div>
 </template>
 
 <script lang='ts'>
 import { Vue, Component, Prop } from "vue-property-decorator";
+import { State, namespace } from "vuex-class";
 import { OTC } from "../store/otc";
+import Btn from "./base/Button.vue";
 
-@Component
+const user_module = namespace("user");
+const session_module = namespace("session");
+
+@Component({ components: { Btn } })
 export default class OTCItem extends Vue {
   @Prop() item!: OTC;
   @Prop() type!: "send" | "received";
+  @State api_url!: string;
+  @session_module.Getter session_id!: string;
+  @user_module.Getter user_id!: string;
+  @session_module.Getter can_post_planning!: boolean;
 
   get otc_action(): string {
     if (this.type === "send") {
@@ -62,17 +83,58 @@ export default class OTCItem extends Vue {
       this.item.price_eur_per_mwh
     );
   }
+
+  async acceptOTC(): Promise<void> {
+    const res = await fetch(
+      `${this.api_url}/session/${this.session_id}/user/${this.user_id}/otc/${this.item.id}/accept`,
+      {
+        method: "PUT"
+      }
+    );
+  }
+
+  async rejectOTC(): Promise<void> {
+    const res = await fetch(
+      `${this.api_url}/session/${this.session_id}/user/${this.user_id}/otc/${this.item.id}/reject`,
+      {
+        method: "PUT"
+      }
+    );
+  }
 }
 </script>
 <style scoped>
 .otc_item__container {
   padding: 0 10px;
+  margin-bottom: 1rem;
+
+  display: grid;
+  grid-template-areas:
+    "user actions"
+    "details actions";
 }
-.otc_item__users {
+.otc_item__user {
+  grid-area: user;
+  text-align: start;
+}
+.otc_item__details {
+  grid-area: details;
   text-align: start;
   padding-left: 1rem;
 }
-.otc_item__details {
-  text-align: start;
+.otc_item__actions {
+  align-self: center;
+  grid-area: actions;
+}
+.otc_item__actions button:first-of-type {
+  margin-right: 0.5rem;
+}
+.otc_item__actions button:last-of-type {
+  margin-left: 0.5rem;
+}
+
+.otc_item__container_refused {
+  color: rgb(160, 160, 160);
+  font-style: italic;
 }
 </style>

--- a/client/src/components/OTCList.vue
+++ b/client/src/components/OTCList.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <OTCItem v-for="otc in otcs" :key="otc.id" :item="otc"/>
+  </div>
+</template>
+
+<script lang='ts'>
+import { Vue, Component } from "vue-property-decorator";
+import { namespace } from "vuex-class";
+import { OTC } from "../store/otc";
+import OTCItem from "./OTCItem.vue";
+
+const otc_module = namespace("otcs");
+
+@Component({ components: { OTCItem } })
+export default class OTCList extends Vue {
+  @otc_module.State otcs!: OTC[];
+}
+</script>
+
+<style>
+</style>

--- a/client/src/components/OTCList.vue
+++ b/client/src/components/OTCList.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <h3>Contrats envoyés</h3>
+    <h3 v-if="otcs_send.length > 0">Contrats envoyés</h3>
     <OTCItem
       v-for="otc in otcs_send"
       :key="otc.id"
       :item="otc"
       :type="'send'"
     />
-    <h3>Contrats reçus</h3>
+    <h3 v-if="otcs_received.length > 0">Contrats reçus</h3>
     <OTCItem
       v-for="otc in otcs_received"
       :key="otc.id"
@@ -32,11 +32,15 @@ export default class OTCList extends Vue {
   @otc_module.State otcs!: OTC[];
 
   get otcs_send(): OTC[] {
-    return this.otcs.filter(otc => otc.user_from === this.username);
+    return this.otcs
+      .filter(otc => otc.user_from === this.username)
+      .sort((a, b) => (a.status > b.status ? 1 : -1));
   }
 
   get otcs_received(): OTC[] {
-    return this.otcs.filter(otc => otc.user_to === this.username);
+    return this.otcs
+      .filter(otc => otc.user_to === this.username)
+      .sort((a, b) => (a.status > b.status ? 1 : -1));
   }
 }
 </script>

--- a/client/src/components/OTCList.vue
+++ b/client/src/components/OTCList.vue
@@ -1,6 +1,19 @@
 <template>
   <div>
-    <OTCItem v-for="otc in otcs" :key="otc.id" :item="otc"/>
+    <h3>Contrats envoyés</h3>
+    <OTCItem
+      v-for="otc in otcs_send"
+      :key="otc.id"
+      :item="otc"
+      :type="'send'"
+    />
+    <h3>Contrats reçus</h3>
+    <OTCItem
+      v-for="otc in otcs_received"
+      :key="otc.id"
+      :item="otc"
+      :type="'received'"
+    />
   </div>
 </template>
 
@@ -10,13 +23,28 @@ import { namespace } from "vuex-class";
 import { OTC } from "../store/otc";
 import OTCItem from "./OTCItem.vue";
 
+const user_module = namespace("user");
 const otc_module = namespace("otcs");
 
 @Component({ components: { OTCItem } })
 export default class OTCList extends Vue {
+  @user_module.Getter username!: string;
   @otc_module.State otcs!: OTC[];
+
+  get otcs_send(): OTC[] {
+    return this.otcs.filter(otc => otc.user_from === this.username);
+  }
+
+  get otcs_received(): OTC[] {
+    return this.otcs.filter(otc => otc.user_to === this.username);
+  }
 }
 </script>
 
-<style>
+<style scoped>
+h3 {
+  margin-left: 0;
+  padding-left: 2rem;
+  text-align: start;
+}
 </style>

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -5,6 +5,7 @@ import { session, SessionState } from "./session";
 import { webSocket, WebSocketState } from "./webSocket";
 import { portfolio, PortfolioState } from "./portfolio";
 import { bids, BidsState } from "./bids";
+import { otcs, OTCState } from "./otc";
 import { results, ResultsState } from "./results";
 
 Vue.use(Vuex);
@@ -18,6 +19,7 @@ export interface RootState {
   ws: WebSocketState;
   portfolio: PortfolioState;
   bids: BidsState;
+  otcs: OTCState;
   results: ResultsState;
 }
 
@@ -35,6 +37,7 @@ const store: StoreOptions<RootState> = {
     webSocket,
     portfolio,
     bids,
+    otcs,
     results,
   },
 };

--- a/client/src/store/otc.ts
+++ b/client/src/store/otc.ts
@@ -1,0 +1,67 @@
+import Vuex, { Module, GetterTree, MutationTree, ActionTree } from "vuex";
+import { RootState } from "./index";
+
+export interface OTC {
+  type: "buy" | "sell";
+  volume_mwh: number;
+  price_eur_per_mwh: number;
+  id: string;
+}
+
+export interface EnergyExchange {
+  volume_mwh: number;
+  price_eur_per_mwh: number;
+}
+
+export interface OTCState {
+  otcs: OTC[];
+}
+
+// ------------------------ STATE -------------------------
+export const state: OTCState = {
+  otcs: [],
+};
+
+// ------------------------ ACTIONS -------------------------
+export const actions: ActionTree<OTCState, RootState> = {
+  async loadOTCsContent({ commit, rootState }): Promise<void> {
+    const api_url = rootState.api_url;
+    const session_id = rootState.session.id;
+    const user_id = rootState.user.user_id;
+    let otcs = [];
+    const res = await await fetch(
+      `${api_url}/session/${session_id}/user/${user_id}/otc`,
+      {
+        method: "GET",
+      }
+    );
+    if (res.status === 200) {
+      otcs = await res.json();
+    } else {
+      console.log(await res.text());
+    }
+    commit("SET_OTCS", otcs);
+  },
+};
+
+// ------------------------ MUTATIONS -------------------------
+export const mutations: MutationTree<OTCState> = {
+  SET_OTCS(state, otcs: OTC[]): void {
+    state.otcs = otcs;
+  },
+  PUSH_OTC(state, otc: OTC): void {
+    state.otcs.push(otc);
+  },
+};
+
+// ------------------------ GETTERS -------------------------
+export const getters: GetterTree<OTCState, RootState> = {};
+
+// ------------------------ MODULE -------------------------
+export const otcs: Module<OTCState, RootState> = {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations,
+};

--- a/client/src/store/otc.ts
+++ b/client/src/store/otc.ts
@@ -65,7 +65,11 @@ export const mutations: MutationTree<OTCState> = {
 };
 
 // ------------------------ GETTERS -------------------------
-export const getters: GetterTree<OTCState, RootState> = {};
+export const getters: GetterTree<OTCState, RootState> = {
+  otcs_accepted(state): OTC[] {
+    return state.otcs.filter((otc) => otc.status === "accepted");
+  },
+};
 
 // ------------------------ MODULE -------------------------
 export const otcs: Module<OTCState, RootState> = {

--- a/client/src/store/otc.ts
+++ b/client/src/store/otc.ts
@@ -55,6 +55,13 @@ export const mutations: MutationTree<OTCState> = {
   PUSH_OTC(state, otc: OTC): void {
     state.otcs.push(otc);
   },
+  UPDATE_OTC(
+    state,
+    update: { otc_id: string; status: "accepted" | "rejected" }
+  ): void {
+    const otc = state.otcs.find((otc) => otc.id === update.otc_id);
+    if (otc !== undefined) otc.status = update.status;
+  },
 };
 
 // ------------------------ GETTERS -------------------------

--- a/client/src/store/otc.ts
+++ b/client/src/store/otc.ts
@@ -2,10 +2,13 @@ import Vuex, { Module, GetterTree, MutationTree, ActionTree } from "vuex";
 import { RootState } from "./index";
 
 export interface OTC {
+  id: string;
+  user_from: string;
+  user_to: string;
   type: "buy" | "sell";
   volume_mwh: number;
   price_eur_per_mwh: number;
-  id: string;
+  status: "pending" | "accepted" | "rejected";
 }
 
 export interface EnergyExchange {

--- a/client/src/store/session.ts
+++ b/client/src/store/session.ts
@@ -61,6 +61,7 @@ export const actions: ActionTree<SessionState, RootState> = {
       context.dispatch("bids/loadBidsContent", {}, { root: true });
       context.dispatch("bids/loadClearingContent", {}, { root: true });
       context.dispatch("bids/loadMarketBids", {}, { root: true });
+      context.dispatch("otcs/loadOTCsContent", {}, { root: true });
       context.dispatch("results/loadResultsContent", {}, { root: true });
       context.dispatch("webSocket/openWebSocket", {}, { root: true });
     }

--- a/client/src/store/webSocket.ts
+++ b/client/src/store/webSocket.ts
@@ -154,6 +154,10 @@ function onMessageCallback(
           break;
         case "new-otc":
           commit("otcs/PUSH_OTC", message.data, opts);
+          break;
+        case 'otc-update':
+          commit("otcs/UPDATE_OTC", message.data, opts);
+          break;
       }
     }
   } catch (error) {

--- a/client/src/store/webSocket.ts
+++ b/client/src/store/webSocket.ts
@@ -132,6 +132,7 @@ function onMessageCallback(
           dispatch("session/loadSessionContent", {}, opts);
           dispatch("portfolio/loadPortfolioContent", {}, opts);
           commit("bids/SET_BIDS", [], opts);
+          commit("otcs/SET_OTCS", [], opts);
           commit("bids/SET_CLEARING", [], opts);
           commit("bids/SET_ENERGY_EXCHANGES", [], opts);
           break;
@@ -151,6 +152,8 @@ function onMessageCallback(
           dispatch("results/loadResultsContent", {}, opts);
           dispatch("bids/loadMarketBids", {}, opts);
           break;
+        case "new-otc":
+          commit("otcs/PUSH_OTC", message.data, opts);
       }
     }
   } catch (error) {

--- a/server/README.md
+++ b/server/README.md
@@ -21,6 +21,10 @@ The following describes the various routes composing the parcelec API.
 - [GET /session/:session_id/user/:user_id/clearing](#Get-specific-information-on-a-user-energy-exchanges-following-market-clearing)
 - [GET /session/:session_id/user/:user_id/results](#Get-energy-and-financial-results-when-a-phase-is-finished)
 - [GET /session/:session_id/clearing/?user_id](#Get-all-the-bids-anonymously-after-a-session-has-cleared)
+- [POST /session/:session_id/user_ir/:user_id/otc](#Post-an-over-the-counter-(OTC)-offer)
+- [GET /session/:session_id/user_ir/:user_id/otc](#Get-all-user's-OTCs-(send-and-received))
+- [PUT /session/:session_id/user/:user_id/otc/:otc_id/accept](#Accept-an-OTC)
+- [PUT /session/:session_id/user/:user_id/otc/:otc_id/reject](#Reject-an-OTC)
 
 
 ## Game session related routes
@@ -313,3 +317,56 @@ The following describes the various routes composing the parcelec API.
         }
       ]
     ```
+
+### Get all user's OTCs (send and received)
+- Route : `GET /session/:session_id/user_ir/:user_id/otc`
+- Response :
+    - Type : `application/json`,
+    - Body : 
+    ``` js
+      [
+        {
+          id: UUID string;
+          user_from: string;
+          user_to: string;
+          session_id: UUID string;
+          phase_no: number;
+          type: "buy" | "sell";
+          volume_mwh: number;
+          price_eur_per_mwh: number;
+          status: "pending" | "accepted" | "rejected";
+        }
+      ]
+    ```
+
+### Post an over-the-counter (OTC) offer
+- Route : `POST /session/:session_id/user_ir/:user_id/otc`
+    - Type : `application/json`,
+    - Body : 
+    ``` js
+      {
+        type: "buy" | "sell",
+        user_to: string,
+        volume_mwh: number,
+        price_eur_per_mwh: number,
+      }
+    ```
+- Response :
+    - Type : `application/json`,
+    - Code : `201` on success
+    - Body : 
+    ``` js
+      {
+        otc_id: UUID string;
+      }
+    ```
+
+### Accept an OTC
+- Route : `PUT /session/:session_id/user/:user_id/otc/:otc_id/accept`
+- Response :
+    - Code : `200` on success
+
+### Reject an OTC 
+- Route : `PUT /session/:session_id/user/:user_id/otc/:otc_id/reject`
+- Response :
+    - Code : `200` on success

--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -150,7 +150,7 @@ CREATE TABLE otc_exchanges
   type TEXT CHECK (type IN ('buy', 'sell')),
   volume_mwh REAL NOT NULL CHECK (volume_mwh > 0),
   price_eur_per_mwh REAL NOT NULL,
-  status TEXT CHECK (type IN ('pending', 'accepted', 'rejected'))
+  status TEXT CHECK (status IN ('pending', 'accepted', 'rejected'))
 );
 
 CREATE TABLE production_plannings 

--- a/server/db/init.sql
+++ b/server/db/init.sql
@@ -139,6 +139,20 @@ CREATE TABLE exchanges
   price_eur_per_mwh REAL NOT NULL
 );
 
+CREATE TABLE otc_exchanges 
+(
+  id UUID PRIMARY KEY NOT NULL,
+  user_from_id UUID REFERENCES users (id) ON DELETE CASCADE,
+  user_to_id UUID REFERENCES users (id) ON DELETE CASCADE,
+  session_id UUID,
+  phase_no INT,
+  FOREIGN KEY (session_id, phase_no) REFERENCES phases (session_id, phase_no) ON DELETE CASCADE,
+  type TEXT CHECK (type IN ('buy', 'sell')),
+  volume_mwh REAL NOT NULL CHECK (volume_mwh > 0),
+  price_eur_per_mwh REAL NOT NULL,
+  status TEXT CHECK (type IN ('pending', 'accepted', 'rejected'))
+);
+
 CREATE TABLE production_plannings 
 (
   user_id UUID REFERENCES users (id) ON DELETE CASCADE,

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import morgan from "morgan";
 import sessions from "./src/routes/sessions";
 import users from "./src/routes/users";
 import bids from "./src/routes/bids";
+import otc from "./src/routes/otc";
 import portfolio from "./src/routes/portfolio";
 import { onConnectionCallback } from "./src/routes/websocket";
 
@@ -17,6 +18,7 @@ app.use(morgan("common"));
 app.use("/", sessions);
 app.use("/", users);
 app.use("/", bids);
+app.use("/", otc);
 app.use("/", portfolio);
 
 const wsServer = new ws.Server({ noServer: true, clientTracking: true });

--- a/server/src/routes/otc.ts
+++ b/server/src/routes/otc.ts
@@ -1,0 +1,259 @@
+/**
+ * Define the route for OTC energy exchanges between players.
+ *  GET /session/:session_id/user/:user_id/otc
+ *  POST /session/:session_id/user/:user_id/otc
+ *  PUT /session/:session_id/user/:user_id/otc/:otc_id/accept
+ *  PUT /session/:session_id/user/:user_id/otc/:otc_id/reject
+ *  PUT /session/:session_id/user/:user_id/otc/:otc_id/counter_offer
+ */
+import express from "express";
+import { v4 as uuid } from "uuid";
+import { OTCEnergyExchange } from "./types";
+import db from "../db";
+import {
+  uuid_regex,
+  CustomError,
+  getSession,
+  getUser,
+  getLastPhaseInfos,
+  checkUserInSessionByName,
+  getUserOTCs,
+} from "./utils";
+import { notifyUser } from "./websocket";
+
+/**
+ * Get list of OTCs involving the user (from or to).
+ * @param req HTTP request
+ * @param res HTTP response
+ */
+export async function getUserOTCsRoute(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  try {
+    // DB checks
+    const session_id = req.params.session_id;
+    const user_id = req.params.user_id;
+    const session = await getSession(session_id);
+    if (session === null)
+      throw new CustomError("Error, no session found with this ID", 404);
+    const user = await getUser(session_id, user_id);
+    if (user === null)
+      throw new CustomError("Error, no user found with this ID", 404);
+
+    // Getting the OTCs from the DB
+    const otcs = await getUserOTCs(session_id, user_id);
+    res.status(200).json(otcs);
+  } catch (error) {
+    if (error instanceof CustomError) {
+      res.status(error.code).end(error.msg);
+    } else {
+      res.status(400).end();
+      throw error;
+    }
+  }
+}
+
+/**
+ * Post a new OTC exchange.
+ * @param req HTTP request
+ * @param res HTTP response
+ */
+export async function postOTC(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  try {
+    const session_id = req.params.session_id;
+    const user_id = req.params.user_id;
+    const session = await getSession(session_id);
+
+    /**
+     * DB checks
+     */
+    if (session === null)
+      throw new CustomError("Error, no session found with this ID", 404);
+    const user = await getUser(session_id, user_id);
+    if (user === null)
+      throw new CustomError("Error, no user found with this ID", 404);
+    const phase_infos = await getLastPhaseInfos(session_id);
+    if (!phase_infos.plannings_allowed)
+      throw new CustomError("Error, cannot post new OTC exchange");
+
+    /**
+     * Payload checks
+     */
+    if (req.body.type === undefined || !["sell", "buy"].includes(req.body.type))
+      throw new CustomError(
+        "Error, must provide a valid OTC type (sell or buy)."
+      );
+    if (
+      req.body.user_to === undefined ||
+      (await checkUserInSessionByName(session_id, req.body.user_to)) === null
+    )
+      throw new CustomError(
+        "Error, must provide a valid username within the session."
+      );
+    const user_to_id = await checkUserInSessionByName(
+      session_id,
+      req.body.user_to
+    );
+    if (req.body.user_to === undefined || user_to_id === null)
+      if (
+        req.body.volume_mwh === undefined ||
+        req.body.volume_mwh === "" ||
+        isNaN(Number(req.body.volume_mwh)) ||
+        Number(req.body.volume_mwh <= 0)
+      )
+        throw new CustomError(
+          "Error, please provide a positive numeric value for the bid volume_mwh"
+        );
+    if (
+      req.body.price_eur_per_mwh === undefined ||
+      req.body.price_eur_per_mwh === "" ||
+      isNaN(Number(req.body.price_eur_per_mwh))
+    )
+      throw new CustomError(
+        "Error, please provide a numeric value for the bid price_eur_per_mwh"
+      );
+
+    /**
+     * Insertion into DB
+     */
+    const otc: OTCEnergyExchange = {
+      id: uuid(),
+      user_from_id: user_id,
+      user_to_id: user_to_id,
+      session_id: session_id,
+      phase_no: phase_infos.phase_no,
+      type: req.body.type,
+      volume_mwh: Number(req.body.volume_mwh),
+      price_eur_per_mwh: Number(req.body.price_eur_per_mwh),
+      status: "pending",
+    };
+
+    await db.query(
+      `INSERT INTO otc_exchanges
+        (
+          id,
+          user_from_id,
+          user_to_id,
+          session_id,
+          phase_no,
+          type,
+          volume_mwh,
+          price_eur_per_mwh,
+          status
+        )
+      VALUES
+        ($1, $2, $3, $4, $5, $6, $7, $8, $9);`,
+      [
+        otc.id,
+        otc.user_from_id,
+        otc.user_to_id,
+        otc.session_id,
+        otc.phase_no,
+        otc.type,
+        otc.volume_mwh,
+        otc.price_eur_per_mwh,
+        otc.status,
+      ]
+    );
+
+    /**
+     * Send response and notify user_to of the new OTC
+     */
+    res.status(201).json({ otc_id: otc.id });
+    notifyUser(session_id, user_to_id, "new-otc", {
+      id: otc.id,
+      user_from: user.name,
+      user_to: req.body.user_to,
+      session_id: otc.session_id,
+      phase_no: otc.phase_no,
+      type: otc.type,
+      volume_mwh: otc.volume_mwh,
+      price_eur_per_mwh: otc.price_eur_per_mwh,
+      status: otc.status,
+    });
+  } catch (error) {
+    if (error instanceof CustomError) {
+      res.status(error.code).end(error.msg);
+    } else {
+      res.status(400).end();
+      throw error;
+    }
+  }
+}
+
+/**
+ * Accept an OTC exchange.
+ * @param req HTTP request
+ * @param res HTTP response
+ */
+export async function acceptOTC(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  try {
+    //
+  } catch (err) {
+    //
+  }
+}
+
+/**
+ *Reject and OTC exchange.
+ * @param req HTTP request
+ * @param res HTTP response
+ */
+export async function rejectOTC(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  try {
+    //
+  } catch (err) {
+    //
+  }
+}
+
+/**
+ * Reject an OTC exchange and make a counter-offer.
+ * @param req HTTP request
+ * @param res HTTP response
+ */
+export async function counterOfferOTC(
+  req: express.Request,
+  res: express.Response
+): Promise<void> {
+  try {
+    //
+  } catch (err) {
+    //
+  }
+}
+
+const router = express.Router();
+
+router.get(
+  `/session/:session_id(${uuid_regex})/user/:user_id(${uuid_regex})/otc`,
+  getUserOTCsRoute
+);
+router.post(
+  `/session/:session_id(${uuid_regex})/user/:user_id(${uuid_regex})/otc`,
+  postOTC
+);
+router.put(
+  `/session/:session_id(${uuid_regex})/user/:user_id(${uuid_regex})/otc/:otc_id(${uuid_regex})/accept`,
+  acceptOTC
+);
+router.put(
+  `/session/:session_id(${uuid_regex})/user/:user_id(${uuid_regex})/otc/:otc_id(${uuid_regex})/reject`,
+  rejectOTC
+);
+router.put(
+  `/session/:session_id(${uuid_regex})/user/:user_id(${uuid_regex})/otc/:otc_id(${uuid_regex})/counter_offer`,
+  counterOfferOTC
+);
+
+export default router;

--- a/server/src/routes/plugins/start_game.ts
+++ b/server/src/routes/plugins/start_game.ts
@@ -49,7 +49,7 @@ export async function checkUserReadyAction(session_id: string): Promise<void> {
     }
     startNewGamePhase(session_id);
     resetUsersReady(session_id);
-  } else if (phase.bids_allowed === true && users_ready) {
+  } else if (phase !== null && phase.bids_allowed === true && users_ready) {
     const t0_sec = Date.now() / 1000;
     // Clear the timer and directly call the clearing callback
     logger.info("skipping to clearing", {
@@ -77,6 +77,7 @@ export async function checkUserReadyAction(session_id: string): Promise<void> {
       [t0_sec, t0_sec + dt_sec, session_id, phase.phase_no]
     );
   } else if (
+    phase !== null &&
     phase.clearing_available === true &&
     phase.plannings_allowed === true &&
     users_ready

--- a/server/src/routes/types.ts
+++ b/server/src/routes/types.ts
@@ -105,6 +105,12 @@ export interface OTCEnergyExchange {
   status: "pending" | "accepted" | "rejected";
 }
 
+export interface OTCEnergyExchangeNoIDs
+  extends Omit<OTCEnergyExchange, "user_from_id" | "user_to_id"> {
+  user_from: string;
+  user_to: string;
+}
+
 export interface PowerPlantDispatch {
   user_id: string;
   session_id: string;

--- a/server/src/routes/types.ts
+++ b/server/src/routes/types.ts
@@ -93,6 +93,18 @@ export interface EnergyExchange {
   price_eur_per_mwh: number;
 }
 
+export interface OTCEnergyExchange {
+  id: string;
+  user_from_id: string;
+  user_to_id: string;
+  session_id: string;
+  phase_no: number;
+  type: "buy" | "sell";
+  volume_mwh: number;
+  price_eur_per_mwh: number;
+  status: "pending" | "accepted" | "rejected";
+}
+
 export interface PowerPlantDispatch {
   user_id: string;
   session_id: string;

--- a/server/src/routes/utils.ts
+++ b/server/src/routes/utils.ts
@@ -13,6 +13,7 @@ import {
   PhaseResults,
   SessionOptions,
   ScenarioOptions,
+  OTCEnergyExchangeNoIDs,
 } from "./types";
 
 export class CustomError extends Error {
@@ -1121,4 +1122,63 @@ export async function checkScenarioID(scenario_id: string): Promise<boolean> {
       )
     ).rows.length === 1
   );
+}
+
+/**
+ * Check by its name if a user belongs to a session. Return its UUID (string) if true,
+ * else return `null`.
+ * @param session_id Session UID
+ * @param username Username, string
+ */
+export async function checkUserInSessionByName(
+  session_id: string,
+  username: string
+): Promise<string> {
+  const rows = (
+    await db.query(
+      `SELECT
+      id
+    FROM users
+    WHERE 
+      session_id=$1
+      AND name=$2;`,
+      [session_id, username]
+    )
+  ).rows;
+  return rows.length === 1 ? rows[0].id : null;
+}
+
+/**
+ * Return the list a user's OTCs.
+ * @param session_id Session UUID
+ * @param user_id User UUID
+ */
+export async function getUserOTCs(
+  session_id: string,
+  user_id: string
+): Promise<OTCEnergyExchangeNoIDs[]> {
+  return (
+    await db.query(
+      `SELECT
+        otc.id AS id,
+        otc.session_id AS session_id,
+        otc.phase_no AS phase_no,
+        otc.type AS type,
+        otc.volume_mwh AS volume_mwh,
+        otc.price_eur_per_mwh AS price_eur_per_mwh,
+        otc.status AS status, 
+        u_from.name AS user_from,
+        u_to.name AS user_to
+      FROM otc_exchanges AS otc
+      INNER JOIN users AS u_from
+        ON otc.user_from_id=u_from.id
+      INNER JOIN users AS u_to
+        ON otc.user_to_id=u_to.id
+      WHERE 
+        (otc.user_from_id=$1
+        OR otc.user_to_id=$1)
+        AND otc.session_id=$2;`,
+      [user_id, session_id]
+    )
+  ).rows as OTCEnergyExchangeNoIDs[];
 }

--- a/server/src/routes/utils.ts
+++ b/server/src/routes/utils.ts
@@ -1158,6 +1158,8 @@ export async function getUserOTCs(
   session_id: string,
   user_id: string
 ): Promise<OTCEnergyExchangeNoIDs[]> {
+  const phase_no = await getLastPhaseNo(session_id);
+  console.log(phase_no);
   return (
     await db.query(
       `SELECT
@@ -1178,8 +1180,9 @@ export async function getUserOTCs(
       WHERE 
         (otc.user_from_id=$1
         OR otc.user_to_id=$1)
-        AND otc.session_id=$2;`,
-      [user_id, session_id]
+        AND otc.session_id=$2
+        AND otc.phase_no=$3;`,
+      [user_id, session_id, phase_no]
     )
   ).rows as OTCEnergyExchangeNoIDs[];
 }

--- a/server/src/routes/utils.ts
+++ b/server/src/routes/utils.ts
@@ -14,6 +14,7 @@ import {
   SessionOptions,
   ScenarioOptions,
   OTCEnergyExchangeNoIDs,
+  OTCEnergyExchange,
 } from "./types";
 
 export class CustomError extends Error {
@@ -1181,4 +1182,29 @@ export async function getUserOTCs(
       [user_id, session_id]
     )
   ).rows as OTCEnergyExchangeNoIDs[];
+}
+
+/**
+ * Find and return an OTC by its ID.
+ * @param otc_id OTC UUID
+ */
+export async function getOTCByID(otc_id: string): Promise<OTCEnergyExchange> {
+  const rows = (
+    await db.query(
+      `SELECT 
+        id,
+        user_from_id,
+        user_to_id,
+        session_id,
+        phase_no,
+        type,
+        volume_mwh,
+        price_eur_per_mwh,
+        status
+      FROM otc_exchanges
+      WHERE id=$1;`,
+      [otc_id]
+    )
+  ).rows as OTCEnergyExchange[];
+  return rows.length === 1 ? rows[0] : null;
 }

--- a/server/src/routes/websocket.ts
+++ b/server/src/routes/websocket.ts
@@ -98,3 +98,31 @@ export function sendUpdateToUsers(
     });
   }
 }
+
+/**
+ * Send an update/message to a specific user of the session, authored
+ * as the SERVER.
+ * @param session_id Session UUID
+ * @param user_id User UUID
+ * @param reason Reason of the message
+ * @param payload Content of the message
+ */
+export function notifyUser(
+  session_id: string,
+  user_id: string,
+  reason: string,
+  payload: any
+): void {
+  if (Object.keys(sessions).includes(session_id)) {
+    if(Object.keys(sessions[session_id]).includes(user_id)) {
+      sessions[session_id][user_id].send(
+        JSON.stringify({
+          username: 'SERVER',
+          date: new Date(),
+          reason: reason,
+          data: payload
+        })
+      )
+    }
+  }
+}

--- a/server/tests/integration/db_utils_new.ts
+++ b/server/tests/integration/db_utils_new.ts
@@ -92,7 +92,7 @@ export async function getUserPortfolio(
 
 /**
  * Create a running session by inserting 2 users and marking them
- * as ready.
+ * as ready. Names of the users are `User 1` and `User 2`.
  * @param session_name Name of the session to create
  */
 export async function insertRunningSession(

--- a/server/tests/integration/routes_otc.spec.ts
+++ b/server/tests/integration/routes_otc.spec.ts
@@ -6,7 +6,6 @@
  *  POST /session/:session_id/user/:user_id/otc/new
  *  PUT /session/:session_id/user/:user_id/otc/:otc_id/accept
  *  PUT /session/:session_id/user/:user_id/otc/:otc_id/reject
- *  PUT /session/:session_id/user/:user_id/otc/:otc_id/counter_offer
  *
  */
 import { v4 as uuid, validate as uuidValidate } from "uuid";
@@ -59,7 +58,7 @@ describe("Posting an OTC offer to another user", () => {
 /**
  * GET /session/:session_id/user/:user_id/otc
  */
-describe("Posting an OTC offer to another user", () => {
+describe("Getting a user's OTC list", () => {
   let session_id: string;
   let user_id: string;
   beforeEach(async () => {
@@ -69,7 +68,7 @@ describe("Posting an OTC offer to another user", () => {
     user_id = await insertNewUser(session_id, "User");
   });
 
-  test("Should post a simple OTC offer", async () => {
+  test("Should get a single OTC item", async () => {
     try {
       const { session_id, user_id_1 } = await insertRunningSession(
         "Running Session"
@@ -95,6 +94,168 @@ describe("Posting an OTC offer to another user", () => {
       expect(uuidValidate(res.body[0].user_to)).toEqual(false);
     } catch (error) {
       fail(error);
+    }
+  });
+});
+
+/**
+ * PUT /session/:session_id/user/:user_id/otc/:otc_id/accept
+ */
+describe("Accepting an OTC offer", () => {
+  let session_id: string;
+  let user_id: string;
+  beforeEach(async () => {
+    await clearDB();
+    await getDefaultScenarioID();
+    session_id = await insertNewSession("Session");
+    user_id = await insertNewUser(session_id, "User");
+  });
+
+  test("Should accept the offer as the to user", async () => {
+    try {
+      const { session_id, user_id_1, user_id_2 } = await insertRunningSession(
+        "Running Session"
+      );
+      const otc_id = (
+        await superagent
+          .post(`${url}/session/${session_id}/user/${user_id_1}/otc`)
+          .send({
+            type: "sell",
+            user_to: "User 2",
+            volume_mwh: 100,
+            price_eur_per_mwh: 50,
+          })
+      ).body.otc_id;
+      const res = await superagent.put(
+        `${url}/session/${session_id}/user/${user_id_2}/otc/${otc_id}/accept`
+      );
+
+      expect(res.status).toEqual(200);
+    } catch (error) {
+      fail(error);
+    }
+  });
+
+  test("Should not be able to accept the offer as the from user", async () => {
+    try {
+      const { session_id, user_id_1, user_id_2 } = await insertRunningSession(
+        "Running Session"
+      );
+      const otc_id = (
+        await superagent
+          .post(`${url}/session/${session_id}/user/${user_id_1}/otc`)
+          .send({
+            type: "sell",
+            user_to: "User 2",
+            volume_mwh: 100,
+            price_eur_per_mwh: 50,
+          })
+      ).body.otc_id;
+      await superagent.put(
+        `${url}/session/${session_id}/user/${user_id_1}/otc/${otc_id}/accept`
+      );
+    } catch (error) {
+      expect(error.response.text).toEqual(
+        "Error, not allowed to modify this OTC"
+      );
+      expect(error.status).toEqual(403);
+    }
+  });
+
+  test("Should not be able to accept an already accepted offer", async () => {
+    try {
+      const { session_id, user_id_1, user_id_2 } = await insertRunningSession(
+        "Running Session"
+      );
+      const otc_id = (
+        await superagent
+          .post(`${url}/session/${session_id}/user/${user_id_1}/otc`)
+          .send({
+            type: "sell",
+            user_to: "User 2",
+            volume_mwh: 100,
+            price_eur_per_mwh: 50,
+          })
+      ).body.otc_id;
+      await superagent.put(
+        `${url}/session/${session_id}/user/${user_id_2}/otc/${otc_id}/accept`
+      );
+      await superagent.put(
+        `${url}/session/${session_id}/user/${user_id_2}/otc/${otc_id}/accept`
+      );
+    } catch (error) {
+      expect(error.response.text).toEqual(
+        "Error, OTC has already been accepted/rejected"
+      );
+      expect(error.status).toEqual(400);
+    }
+  });
+});
+
+/**
+ * PUT /session/:session_id/user/:user_id/otc/:otc_id/reject
+ */
+describe("Rejecting an OTC offer", () => {
+  let session_id: string;
+  let user_id: string;
+  beforeEach(async () => {
+    await clearDB();
+    await getDefaultScenarioID();
+    session_id = await insertNewSession("Session");
+    user_id = await insertNewUser(session_id, "User");
+  });
+
+  test("Should reject the offer as the to user", async () => {
+    try {
+      const { session_id, user_id_1, user_id_2 } = await insertRunningSession(
+        "Running Session"
+      );
+      const otc_id = (
+        await superagent
+          .post(`${url}/session/${session_id}/user/${user_id_1}/otc`)
+          .send({
+            type: "sell",
+            user_to: "User 2",
+            volume_mwh: 100,
+            price_eur_per_mwh: 50,
+          })
+      ).body.otc_id;
+      const res = await superagent.put(
+        `${url}/session/${session_id}/user/${user_id_2}/otc/${otc_id}/reject`
+      );
+
+      expect(res.status).toEqual(200);
+    } catch (error) {
+      fail(error);
+    }
+  });
+
+  test("Should not be able to reject an already rejected offer", async () => {
+    try {
+      const { session_id, user_id_1, user_id_2 } = await insertRunningSession(
+        "Running Session"
+      );
+      const otc_id = (
+        await superagent
+          .post(`${url}/session/${session_id}/user/${user_id_1}/otc`)
+          .send({
+            type: "sell",
+            user_to: "User 2",
+            volume_mwh: 100,
+            price_eur_per_mwh: 50,
+          })
+      ).body.otc_id;
+      await superagent.put(
+        `${url}/session/${session_id}/user/${user_id_2}/otc/${otc_id}/reject`
+      );
+      await superagent.put(
+        `${url}/session/${session_id}/user/${user_id_2}/otc/${otc_id}/reject`
+      );
+    } catch (error) {
+      expect(error.response.text).toEqual(
+        "Error, OTC has already been accepted/rejected"
+      );
+      expect(error.status).toEqual(400);
     }
   });
 });

--- a/server/tests/integration/routes_otc.spec.ts
+++ b/server/tests/integration/routes_otc.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Integration tests relative to OTC routes.
+ *
+ * The tested routes are :
+ *  GET /session/:session_id/user/:user_id/otc
+ *  POST /session/:session_id/user/:user_id/otc/new
+ *  PUT /session/:session_id/user/:user_id/otc/:otc_id/accept
+ *  PUT /session/:session_id/user/:user_id/otc/:otc_id/reject
+ *  PUT /session/:session_id/user/:user_id/otc/:otc_id/counter_offer
+ *
+ */
+import { v4 as uuid, validate as uuidValidate } from "uuid";
+import superagent from "superagent";
+import {
+  clearDB,
+  getDefaultScenarioID,
+  insertNewSession,
+  insertNewUser,
+  insertRunningSession,
+} from "./db_utils_new";
+
+const url = process.env.API_URL;
+
+/**
+ * POST /session/:session_id/user/:user_id/otc
+ */
+describe("Posting an OTC offer to another user", () => {
+  let session_id: string;
+  let user_id: string;
+  beforeEach(async () => {
+    await clearDB();
+    await getDefaultScenarioID();
+    session_id = await insertNewSession("Session");
+    user_id = await insertNewUser(session_id, "User");
+  });
+
+  test("Should post a simple OTC offer", async () => {
+    try {
+      const { session_id, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
+      const res = await superagent
+        .post(`${url}/session/${session_id}/user/${user_id_1}/otc`)
+        .send({
+          type: "sell",
+          user_to: "User 2",
+          volume_mwh: 100,
+          price_eur_per_mwh: 50,
+        });
+      expect(res.status).toEqual(201);
+      expect(res.body).toHaveProperty("otc_id");
+      expect(uuidValidate(res.body.otc_id)).toEqual(true);
+    } catch (error) {
+      fail(error);
+    }
+  });
+});
+
+/**
+ * GET /session/:session_id/user/:user_id/otc
+ */
+describe("Posting an OTC offer to another user", () => {
+  let session_id: string;
+  let user_id: string;
+  beforeEach(async () => {
+    await clearDB();
+    await getDefaultScenarioID();
+    session_id = await insertNewSession("Session");
+    user_id = await insertNewUser(session_id, "User");
+  });
+
+  test("Should post a simple OTC offer", async () => {
+    try {
+      const { session_id, user_id_1 } = await insertRunningSession(
+        "Running Session"
+      );
+      await superagent
+        .post(`${url}/session/${session_id}/user/${user_id_1}/otc`)
+        .send({
+          type: "sell",
+          user_to: "User 2",
+          volume_mwh: 100,
+          price_eur_per_mwh: 50,
+        });
+      const res = await superagent.get(
+        `${url}/session/${session_id}/user/${user_id_1}/otc`
+      );
+
+      expect(res.status).toEqual(200);
+      expect(Array.isArray(res.body)).toEqual(true);
+      expect(res.body.length).toEqual(1);
+
+      expect(uuidValidate(res.body[0].id)).toEqual(true);
+      expect(uuidValidate(res.body[0].user_from)).toEqual(false);
+      expect(uuidValidate(res.body[0].user_to)).toEqual(false);
+    } catch (error) {
+      fail(error);
+    }
+  });
+});


### PR DESCRIPTION
Direct exchanges of energy between players (OTC = Over-the-counter). Can be done anytime before the closing of plannings reception.

- Add new SQL table and corresponding TS types
- Update the end game computation to account for OTC flows (energy and money)
- Add new dedicated routes (add, get list, reject and accept)
- Update front UI to allow OTC offers management